### PR TITLE
QwtPlot: set "autoReplot" option to False by default

### DIFF
--- a/qwt/plot.py
+++ b/qwt/plot.py
@@ -309,7 +309,7 @@ class QwtPlot(QFrame, QwtPlotDict):
         self.__data.layout = QwtPlotLayout()
         self.__data.autoReplot = False
 
-        self.setAutoReplot(True)
+        self.setAutoReplot(False)
         self.setPlotLayout(self.__data.layout)
 
         # title


### PR DESCRIPTION
set auto-replot to False as default
From Bertrand Rosse