### PR TITLE
QwtPlot.canvasMap: fixed when axisScaleDiv returns None

### DIFF
--- a/qwt/plot.py
+++ b/qwt/plot.py
@@ -1461,7 +1461,8 @@ class QwtPlot(QFrame, QwtPlotDict):
 
         map_.setTransformation(self.axisScaleEngine(axisId).transformation())
         sd = self.axisScaleDiv(axisId)
-        map_.setScaleInterval(sd.lowerBound(), sd.upperBound())
+        if sd:
+            map_.setScaleInterval(sd.lowerBound(), sd.upperBound())
 
         if self.axisEnabled(axisId):
             s = self.axisWidget(axisId)


### PR DESCRIPTION
axisScaleDiv is sometimes None