### PR TITLE
Qrect issue 63

### DIFF
--- a/qwt/plot_canvas.py
+++ b/qwt/plot_canvas.py
@@ -82,7 +82,7 @@ class QwtStyleSheetRecorder(QwtNullPaintDevice):
 
     def drawRects(self, rects, count):
         for i in range(count):
-            self.border.rectList += [rects.getRect().index(i) if isinstance(rect, (QRectF, QRect)) else rects[i]]
+            self.border.rectList += [rects.getRect().index(i) if isinstance(rects, (QRectF, QRect)) else rects[i]]
 
     def drawPath(self, path):
         rect = QRectF(QPointF(0.0, 0.0), self.__size)

--- a/qwt/plot_canvas.py
+++ b/qwt/plot_canvas.py
@@ -32,7 +32,7 @@ from qtpy.QtGui import (
     QPolygonF,
 )
 from qtpy.QtWidgets import QFrame, QStyleOption, QStyle
-from qtpy.QtCore import Qt, QSizeF, QEvent, QPointF, QRectF
+from qtpy.QtCore import Qt, QSizeF, QEvent, QPointF, QRect, QRectF
 from qtpy import QtCore as QC
 
 
@@ -82,7 +82,7 @@ class QwtStyleSheetRecorder(QwtNullPaintDevice):
 
     def drawRects(self, rects, count):
         for i in range(count):
-            self.border.rectList += [rects[i]]
+            self.border.rectList += [rects[i] if isinstance(rect, (QRectF, QRect)) else rects.getRect().index(i)]
 
     def drawPath(self, path):
         rect = QRectF(QPointF(0.0, 0.0), self.__size)

--- a/qwt/plot_canvas.py
+++ b/qwt/plot_canvas.py
@@ -81,8 +81,11 @@ class QwtStyleSheetRecorder(QwtNullPaintDevice):
             self.__origin = state.brushOrigin()
 
     def drawRects(self, rects, count):
+        if isinstance(rects, (QRectF, QRect)):
+            self.border.rectList += [rects]
+            return
         for i in range(count):
-            self.border.rectList += [rects.getRect().index(i) if isinstance(rects, (QRectF, QRect)) else rects[i]]
+            self.border.rectList += [rects.getRect().index[i]]
 
     def drawPath(self, path):
         rect = QRectF(QPointF(0.0, 0.0), self.__size)

--- a/qwt/plot_canvas.py
+++ b/qwt/plot_canvas.py
@@ -82,7 +82,7 @@ class QwtStyleSheetRecorder(QwtNullPaintDevice):
 
     def drawRects(self, rects, count):
         for i in range(count):
-            self.border.rectList += [rects[i] if isinstance(rect, (QRectF, QRect)) else rects.getRect().index(i)]
+            self.border.rectList += [rects.getRect().index(i) if isinstance(rect, (QRectF, QRect)) else rects[i]]
 
     def drawPath(self, path):
         rect = QRectF(QPointF(0.0, 0.0), self.__size)


### PR DESCRIPTION
Fixed the issue (#63) when stylesheets is introduced and `qwt.plot_canvas.QwtStyleSheetRecorder.drawRects` called with dynamic arguments.

Function now checks if rects is a QRect or QRectF or treats it as a subscriptable instance.

